### PR TITLE
conflicting ports with qbittorrent

### DIFF
--- a/templates/sabnzbd.yml
+++ b/templates/sabnzbd.yml
@@ -14,8 +14,8 @@
       - org.hotio.pullio.notify=${PULLIO_NOTIFY}
       - org.hotio.pullio.discord.webhook=${PULLIO_DISCORD_WEBHOOK}
     ports:
-      - 8080:8080
-      - 9090:9090
+      - 9090:8080
+      - 9191:9090
     environment:
       - PUID=${PUID}
       - PGID=${PGID}


### PR DESCRIPTION
Different ports so it works with script when people select sabnzbd + qbittorrent. They both use 8080.

# Pull request

**Purpose**
Detailed description why you created this Pull Request.

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you add a new template for a application take a look at [DockSTARTer](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps) for examples being I used them as base for the others templates

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
