### PR TITLE
Include Hostname in Notifiarr container

### DIFF
--- a/templates/notifiarr.yml
+++ b/templates/notifiarr.yml
@@ -4,6 +4,7 @@
     container_name: notifiarr
     image: golift/notifiarr:latest
     restart: unless-stopped
+    user: ${PUID}:${GUID}
     hostname: notifiarr
     logging:
       driver: json-file

--- a/templates/notifiarr.yml
+++ b/templates/notifiarr.yml
@@ -13,8 +13,6 @@
     ports:
       - 5454:5454
     environment:
-      - PUID=${PUID}
-      - PGID=${PGID}
       - TZ=${TZ}
     volumes:
       - ${DOCKERCONFDIR}/notifiarr:/config

--- a/templates/notifiarr.yml
+++ b/templates/notifiarr.yml
@@ -4,6 +4,7 @@
     container_name: notifiarr
     image: golift/notifiarr:latest
     restart: unless-stopped
+    hostname: notifiarr
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
**Purpose**
The Notifiarr container requires a non-random hostname to operate reliably. This sets it.
The PUID ands GUID variables are not used in this container, so moved those to where they're useful.

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
