### PR TITLE
new workflow: create template-list.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/create-json-list.yml
+++ b/.github/workflows/create-json-list.yml
@@ -1,0 +1,34 @@
+name: create template-list.json
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "templates/**"
+  pull_request:
+    paths:
+      - "templates/**"
+jobs:
+  create-json:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Create templates/template-file-list.json
+        run: |
+          cd templates
+          template_file_list=()
+          for f in *.yml; do
+            template_file_list+=("${f/.yml/}")
+          done
+          jq -n --arg v "${template_file_list[*]}" '{"templates": $v | split(" ")}' > template-file-list.json
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Automated Change template-file-list.json
+          file_pattern: templates/template-file-list.json
+          commit_user_name: My GitHub Actions Bot # defaults to "github-actions[bot]"
+          commit_user_email: my-github-actions-bot@example.org # defaults to "github-actions[bot]@users.noreply.github.com"
+          commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run


### PR DESCRIPTION
An action to automatically create a json array of the available templates that can be used via curl to get a list of available templates. Allowing me to avoid scraping the html.

It will provide a file with a json array of the templates there is always a consistent and accurate way to list them.

# Pull request

**Purpose**

Every time there is a push or pull request to the `templates/` directory this workflow will fire and create a `templates/template-list.json`. If there file changes from due to a new or removed application template the modified file will be automatically committed, otherwise nothing happens.

**Approach**

Create the json array like this

```
      - name: Create templates/template-file-list.json
        run: |
          cd templates
          template_file_list=()
          for f in *.yml; do
            template_file_list+=("${f/.yml/}")
          done
          jq -n --arg v "${template_file_list[*]}" '{"templates": $v | split(" ")}' > template-file-list.json
```

Auto commit using this action and these options. See here for more info

https://github.com/stefanzweifel/git-auto-commit-action

```
      - uses: stefanzweifel/git-auto-commit-action@v4
        with:
          commit_message: Automated Change template-file-list.json
          file_pattern: templates/template-file-list.json
          commit_user_name: My GitHub Actions Bot # defaults to "github-actions[bot]"
          commit_user_email: my-github-actions-bot@example.org # defaults to "github-actions[bot]@users.noreply.github.com"
          commit_author: Author <actions@github.com> # defaults to author of the commit that triggered the run
```

The output will look like this

```json
{
  "templates": [
    "authelia",
    "bazarr",
    "dozzle",
    "emby",
    "lidarr",
    "notifiarr",
    "nzbget",
    "overseerr",
    "plex",
    "prowlarr",
    "qbittorrent",
    "radarr",
    "recyclarr",
    "sabnzbd",
    "sonarr",
    "tautulli",
    "watchtower"
  ]
}
```

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x ] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
