### PR TITLE
Added Version Check and proper Service file

### DIFF
--- a/script/tun.service
+++ b/script/tun.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run tun at startup
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/sbin/insmod /lib/modules/tun.ko
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Pull request
Created PR after a talk with Bokk, added version check for him and swapped the tun creation to a proper service file

Added a version check so it will throw an error on DSM versions below 7.0+

Added a proper service file for the tun file creation, enabling and starting it.

**Purpose**
With DSM 7 we now have the possibility to setup proper service files.

Tested Version check on DSM 7.1.1 and DSM 6.2.4
Tested service creation on DSM 7.1.1
Did not test full script, due of existing setup

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
