### PR TITLE
Added template for Jellyfin

### DIFF
--- a/templates/jellyfin.yml
+++ b/templates/jellyfin.yml
@@ -17,7 +17,7 @@
       - org.hotio.pullio.notify=${PULLIO_NOTIFY}
       - org.hotio.pullio.discord.webhook=${PULLIO_DISCORD_WEBHOOK}
     ports:
-      - 32400:32400
+      - 8096:8096
     environment:
       - PUID=${PUID}
       - PGID=${PGID}

--- a/templates/jellyfin.yml
+++ b/templates/jellyfin.yml
@@ -1,0 +1,33 @@
+# Plex - https://hotio.dev/containers/plex/
+#
+# Don't forget to create the directory, change chown command if needed (the user:group part)
+# sudo -u docker mkdir -m=00775 /volume1/docker/appdata/plex
+#
+  plex:
+    container_name: jellyfin
+    image: cr.hotio.dev/hotio/jellyfin
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-file: ${DOCKERLOGGING_MAXFILE}
+        max-size: ${DOCKERLOGGING_MAXSIZE}
+    labels:
+      - org.hotio.pullio.update=${PULLIO_UPDATE}
+      - org.hotio.pullio.notify=${PULLIO_NOTIFY}
+      - org.hotio.pullio.discord.webhook=${PULLIO_DISCORD_WEBHOOK}
+    ports:
+      - 32400:32400
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+      - UMASK=002
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${DOCKERCONFDIR}/jellyfin:/config:rw
+      - ${DOCKERSTORAGEDIR}/media:/data/media:rw
+    devices:                                        # optional: if you have a Syno with an Intel CPU with quicksync and want hardware transcoding
+      - /dev/dri:/dev/dri                           # optional: if you have a Syno with an Intel CPU with quicksync and want hardware transcoding
+#   tmpfs:                                          # optional: if you have a Syno with enough RAM, you can uncomment this line to enable transcoding in RAM.
+#     - /transcode                                  # optional: if you have a Syno with enough RAM, you can uncomment this line to enable transcoding in RAM.

--- a/templates/jellyfin.yml
+++ b/templates/jellyfin.yml
@@ -1,9 +1,9 @@
-# Plex - https://hotio.dev/containers/plex/
+# Jellyfin - https://hotio.dev/containers/jellyfin/
 #
 # Don't forget to create the directory, change chown command if needed (the user:group part)
-# sudo -u docker mkdir -m=00775 /volume1/docker/appdata/plex
+# sudo -u docker mkdir -m=00775 /volume1/docker/appdata/jellyfin
 #
-  plex:
+  jellyfin:
     container_name: jellyfin
     image: cr.hotio.dev/hotio/jellyfin
     restart: unless-stopped


### PR DESCRIPTION
A template for Jellyfin based on the template for Plex. I've removed some options that are made for the Plex container and changed anything plex related to Jellyfin

# Pull request

**Purpose**
I want to add a Jellyfin template so people who use Jellyfin don't have to modify or create a new compose.

**Approach**
Edited the existing Plex template

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you add a new template for a application take a look at [DockSTARTer](https://github.com/GhostWriters/DockSTARTer/tree/master/compose/.apps) for examples being I used them as base for the others templates

**Requirements**
Check all boxes as they are completed

- [*] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [*] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
