### PR TITLE
Update recyclarr.yml

### DIFF
--- a/templates/recyclarr.yml
+++ b/templates/recyclarr.yml
@@ -16,6 +16,5 @@
     environment:
       - TZ=${TZ}
       - CRON_SCHEDULE=@daily
-    init: true
     volumes:
       - ${DOCKERCONFDIR}/recyclarr:/config


### PR DESCRIPTION
Fixes tini (7)] Tini is not running as PID 1 and isn't registered as a child subreaper.