### PR TITLE
Fix wg0 DNS comment

### DIFF
--- a/templates/qbittorrent.yml
+++ b/templates/qbittorrent.yml
@@ -6,8 +6,8 @@
 # If you want to use VPN follow the instructions below.
 # To enable VPN set "VPN_ENABLED=true" in the .env, and uncomment the 'devices' section below. If you don't want VPN enabled set "VPN_ENABLED=false"
 # Start the container, and in your /appdata/qbittorrent a wireguard folder will be created where you need to place your wg0.conf file you got from your VPN provider and rename it to wg0-fix.conf
-# Remove the `DNS = 1.1.1.1` line from the wg0.conf
-# Remove any preexisting preup or postup from your wg0.conf file
+# Remove the line starting with `DNS = ` from wg0-fix.conf
+# Remove any preexisting preup or postup from your wg0-fix.conf file
 # Restart qbittorrent after you made the changes to wg0 config file.
 #
 # If you are getting a "Failed to open '/dev/net/tun'" error, run the commands below.


### PR DESCRIPTION
# Pull request

**Purpose**
Hope I'm not mistaken, but should we not make sure to remove the DNS line in our `wg0-fix.conf` file, regardless of its value? The container then sets the DNS values, right?

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides-Synology-Templates/blob/main/.github/CODE_OF_CONDUCT.md).
