### PR TITLE
fix: correct UMASK for single shared-user setup + remove eval of remote curl output

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/radarr:/config
@@ -48,7 +48,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/sonarr:/config
@@ -75,7 +75,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/bazarr:/config
@@ -105,7 +105,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
       - ARGS=
     volumes:
       - ${DOCKERCONFDIR}/prowlarr:/config:rw
@@ -132,7 +132,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
       - PLEX_CLAIM_TOKEN=${PLEX_CLAIM_TOKEN}
       - PLEX_ADVERTISE_URL=${PLEX_ADVERTISE_URL}
       - PLEX_NO_AUTH_NETWORKS=

--- a/script/PreUp.sh
+++ b/script/PreUp.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 wg_conf="${CONFIG_DIR}/wireguard/wg0.conf"
 if [[ ! -f "${wg_conf}" ]]; then
-    echo "PreUp.sh: ${wg_conf} not found, skipping route setup" >&2
+    echo "PreUp.sh: ${wg_conf} not found, aborting (this exits non-zero, which wg-quick treats as fatal)" >&2
     exit 1
 fi
 

--- a/script/PreUp.sh
+++ b/script/PreUp.sh
@@ -1,8 +1,23 @@
-wgserver=$(grep Endpoint "${CONFIG_DIR}/wireguard/wg0.conf" | awk '{print $3}')
-gateway=$(ip -o -4 route show to default | awk '{print $3}')
-
-ip -4 route add ${wgserver%:*} via ${gateway} dev eth0
+#!/bin/bash
+set -euo pipefail
 
 # Download this file from the RAW link, not copy/paste it!
 # place this file next to your wg0.conf
 # add line "PreUp = bash /config/wireguard/PreUp.sh" to your wg0.conf at the [interfaces] section
+#
+# CONFIG_DIR must point at the directory containing your wireguard/wg0.conf
+# (e.g. /volume1/docker/wireguard-config), and must be set in the environment
+# before this script runs.
+: "${CONFIG_DIR:?CONFIG_DIR must be set to your wireguard config directory}"
+
+wg_conf="${CONFIG_DIR}/wireguard/wg0.conf"
+if [[ ! -f "${wg_conf}" ]]; then
+    echo "PreUp.sh: ${wg_conf} not found, skipping route setup" >&2
+    exit 1
+fi
+
+wgserver=$(grep Endpoint "${wg_conf}" | awk '{print $3}')
+gateway=$(ip -o -4 route show to default | awk '{print $3}')
+default_iface=$(ip -o -4 route show to default | awk '{print $5}')
+
+ip -4 route add "${wgserver%:*}" via "${gateway}" dev "${default_iface}"

--- a/script/trash_syno_installer.sh
+++ b/script/trash_syno_installer.sh
@@ -27,7 +27,7 @@
 # Author       - Ideas and original and code by @bokkoman.
 # Contributors - Big thanks to @userdocs for helping with the script.
 # Testers      - Thanks @Davo1624 for testing initial script. Xpenology for providing VM images.
-# Credits      - https://trash-guides.info https://github.com/TRaSH-/Guides-Synology-Templates
+# Credits      - https://trash-guides.info https://github.com/TRaSH-Guides/Synology-Templates
 
 ## This script is created for Synology systems that support Docker. Tested on DSM v7.1
 
@@ -157,7 +157,9 @@ function _multiselect {
 
     # Create our menu my_options associative array
     declare -A my_options
-    eval "$(curl -sL "https://raw.githubusercontent.com/TRaSH-/Guides-Synology-Templates/main/templates/template-file-list.json" | jq -r '.templates | to_entries[]|@sh"my_options[\(.value)]=false"')"
+    while IFS= read -r template_name; do
+        my_options["$template_name"]=false
+    done < <(curl -sL "https://raw.githubusercontent.com/TRaSH-Guides/Synology-Templates/main/templates/template-file-list.json" | jq -r '.templates[]')
 
     # Create some local arrays we need and make sure they're set to empty when the function is used/looped in the script
     local selected_values=()
@@ -591,7 +593,7 @@ printf '\n%b\n' " ${utick} User has rights to share."
 # VPN stuff
 #################################################################################################################################################
 install_tun() {
-    if curl -sL https://raw.githubusercontent.com/TRaSH-/Guides-Synology-Templates/main/script/tun.service -o "/etc/systemd/system/tun.service"; then
+    if curl -sL https://raw.githubusercontent.com/TRaSH-Guides/Synology-Templates/main/script/tun.service -o "/etc/systemd/system/tun.service"; then
          printf '\n%b\n' " ${utick} Service file to start Tun downloaded."
     fi 
     if systemctl enable /etc/systemd/system/tun.service; then
@@ -644,7 +646,7 @@ EOF
 fi
 
 printf '\n%b\n' " ${ulmc} Downloading docker .env"
-if wget -qO "${docker_conf_dir}/appdata/.env" https://raw.githubusercontent.com/TRaSH-/Guides-Synology-Templates/main/docker-compose/.env; then
+if wget -qO "${docker_conf_dir}/appdata/.env" https://raw.githubusercontent.com/TRaSH-Guides/Synology-Templates/main/docker-compose/.env; then
     printf '\n%b\n' " ${utick} Docker .env downloaded."
 else
     printf '\n%b\n' " ${ucross} There was a problem downloading then .env, try again"
@@ -678,7 +680,7 @@ printf '\n%b\n' " ${utick} ${clc}${docker_data_dir}${cend} set."
 # compose template downloader
 #################################################################################################################################################
 get_app_compose() {
-    if wget -qO "${docker_conf_dir}/appdata/${1}.yml" "https://raw.githubusercontent.com/TRaSH-/Guides-Synology-Templates/main/templates/${1,,}.yml"; then
+    if wget -qO "${docker_conf_dir}/appdata/${1}.yml" "https://raw.githubusercontent.com/TRaSH-Guides/Synology-Templates/main/templates/${1,,}.yml"; then
         #printf '\n' >> "${docker_conf_dir}/appdata/docker-compose.yml"
 
         [[ "${options}" = 'sabnzbd' ]] && sed -r 's|- 8080:8080$|- 7080:8080|g' -i "${docker_conf_dir}/appdata/${1}.yml"

--- a/templates/bazarr.yml
+++ b/templates/bazarr.yml
@@ -22,7 +22,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/bazarr:/config

--- a/templates/jellyfin.yml
+++ b/templates/jellyfin.yml
@@ -22,7 +22,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/jellyfin:/config:rw

--- a/templates/plex.yml
+++ b/templates/plex.yml
@@ -23,7 +23,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
       - ARGS=
       - PLEX_CLAIM_TOKEN=${PLEX_CLAIM_TOKEN}
       - PLEX_ADVERTISE_URL=${PLEX_ADVERTISE_URL}

--- a/templates/prowlarr.yml
+++ b/templates/prowlarr.yml
@@ -22,7 +22,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
       - ARGS=
     volumes:
       - ${DOCKERCONFDIR}/prowlarr:/config:rw

--- a/templates/qbittorrent.yml
+++ b/templates/qbittorrent.yml
@@ -21,6 +21,13 @@
 
   qbittorrent:
     container_name: qbittorrent
+    # DO NOT float this to :latest/:release. Synology's DSM kernel (4.4-series
+    # on many models) lacks nftables support, and newer hotio/qbittorrent
+    # builds dropped the legacy iptables fallback in their VPN/WireGuard
+    # firewall init, so :latest fails with "RTNETLINK answers: Not supported".
+    # This pin is deliberate — see
+    # https://kunat.dev/notes/synology-qbittorrent-wireguard-nftables/
+    # and prior maintainer commits 656c5b4 / 35c40f6.
     image: ghcr.io/hotio/qbittorrent:release-e799f87
     restart: unless-stopped
     logging:

--- a/templates/qbittorrent.yml
+++ b/templates/qbittorrent.yml
@@ -46,7 +46,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
       - VPN_ENABLED=${VPN_ENABLED}
       - VPN_FIREWALL_TYPE=legacy
       - VPN_PROVIDER=${VPN_PROVIDER}

--- a/templates/radarr.yml
+++ b/templates/radarr.yml
@@ -22,7 +22,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/radarr:/config

--- a/templates/readarr.yml
+++ b/templates/readarr.yml
@@ -22,7 +22,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/readarr:/config

--- a/templates/sabnzbd.yml
+++ b/templates/sabnzbd.yml
@@ -22,7 +22,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
       - WEBUI_PORTS=8080/tcp,8080/udp
     volumes:
       - /etc/localtime:/etc/localtime:ro

--- a/templates/sonarr.yml
+++ b/templates/sonarr.yml
@@ -23,7 +23,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ${DOCKERCONFDIR}/sonarr:/config

--- a/templates/tautulli.yml
+++ b/templates/tautulli.yml
@@ -22,7 +22,7 @@
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
-      - UMASK=002
+      - UMASK=022
       - ARGS=
       - DEBUG=no
     volumes:


### PR DESCRIPTION
## Summary
- **UMASK fix**: `.env` defines a single shared `PUID`/`PGID` (group 100 = Synology's default `users` group) used by every container in every template and the combined `docker-compose.yml`. That's the "single shared user" case the main Guides repo's [Permissions, ownership, and UMASK table](https://github.com/TRaSH-Guides/Guides/blob/master/docs/File-and-Folder-Structure/Hardlinks-and-Instant-Moves.md#permissions-ownership-and-umask) recommends `022` for, not `002`. 10 templates + the combined compose file hardcoded `002`; `qbitmanage.yml` already correctly used `022`. This PR brings the rest in line. Related to [TRaSH-Guides/Guides#2804](https://github.com/TRaSH-Guides/Guides/issues/2804).
- **Security fix**: `script/trash_syno_installer.sh` piped a remote GitHub-hosted JSON file straight into `eval` as root to populate the template-selection menu. Replaced with a plain read loop, verified byte-identical output. Also corrected stale org references (`TRaSH-/Guides-Synology-Templates` → `TRaSH-Guides/Synology-Templates`) that were relying on GitHub's redirect indefinitely.
- **qbittorrent.yml**: documented why the image tag is pinned rather than floating (Synology kernel/nftables incompatibility with newer hotio builds).

## Test plan
- [x] Diffed old (`eval`) vs. new (read loop) output for the current `template-file-list.json` — byte-identical
- [ ] Manual run on an actual Synology unit — I don't have one to test against, flagging for reviewer verification