### PR TITLE
chore(renovate): migrate from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    "customManagers:githubActionsVersions",
+    "schedule:weekly",
+    ":automergePr",
+    ":automergeDigest",
+    ":automergeLinters",
+    ":automergeStableNonMajor",
+    ":automergeTesters",
+    ":automergeTypes",
+    ":enableVulnerabilityAlerts",
+    ":renovatePrefix"
+  ],
+  "baseBranchPatterns": ["$default"],
+  "minimumReleaseAge": "3 days",
+  "rebaseWhen": "conflicted",
+  "ignorePaths": ["docker-compose/**"],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions non-major dependencies",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Group GitHub Actions major dependencies",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "GitHub Actions major",
+      "groupSlug": "github-actions-major",
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Replaces `.github/dependabot.yml` with `.github/renovate.json`, matching the config style already used in the sibling `TRaSH-Guides/Guides` repo. Only the `github-actions` manager is relevant here (no `pyproject.toml`/`Cargo.toml`/`.pre-commit-config.yaml` in this repo). `docker-compose/**` is excluded from digest-pinning — those files are illustrative DockSTARTer-style example templates using floating tags on purpose, not pinned deployments.

## Operator actions required (config is inert without these)
- [ ] Enable "Allow auto-merge" on the repo (currently off)
- [x] Install the Renovate GitHub App on this repo
- [x] Close stale Dependabot PRs #220 and #221 — Renovate will re-propose both as majors requiring manual review

## Test plan
- [x] `npx --yes --package renovate renovate-config-validator .github/renovate.json` — validated successfully